### PR TITLE
LogComponent and MidiSettings

### DIFF
--- a/JUCE GUI/Moving-Speakers-GUI/Moving-Speakers-GUI.jucer
+++ b/JUCE GUI/Moving-Speakers-GUI/Moving-Speakers-GUI.jucer
@@ -3,9 +3,22 @@
 <JUCERPROJECT id="nq3hBm" name="Moving-Speakers-GUI" projectType="guiapp" jucerVersion="5.4.7">
   <MAINGROUP id="QcUkDh" name="Moving-Speakers-GUI">
     <GROUP id="{5C9B4581-255D-3259-6EA1-F215ADCC8E3B}" name="Source">
-      <FILE id="cUz8Cm" name="MainComponent.h" compile="0" resource="0" file="Source/MainComponent.h"/>
-      <FILE id="mZXg9O" name="MainComponent.cpp" compile="1" resource="0"
-            file="Source/MainComponent.cpp"/>
+      <GROUP id="{EE2AA553-5B17-E516-52BE-8D82D8D4B452}" name="Util">
+        <FILE id="WSCkp1" name="MidiSettings.cpp" compile="1" resource="0"
+              file="Source/MidiSettings.cpp"/>
+        <FILE id="dxNawJ" name="MidiSettings.h" compile="0" resource="0" file="Source/MidiSettings.h"/>
+      </GROUP>
+      <GROUP id="{62FA6BFF-8C52-5DAF-61DD-2143AA85F673}" name="Ui">
+        <FILE id="JKBL70" name="TabsComponent.cpp" compile="1" resource="0"
+              file="Source/TabsComponent.cpp"/>
+        <FILE id="en5AGm" name="TabsComponent.h" compile="0" resource="0" file="Source/TabsComponent.h"/>
+        <FILE id="idmJ8f" name="LogComponent.cpp" compile="1" resource="0"
+              file="Source/LogComponent.cpp"/>
+        <FILE id="RLwLgd" name="LogComponent.h" compile="0" resource="0" file="Source/LogComponent.h"/>
+        <FILE id="cUz8Cm" name="MainComponent.h" compile="0" resource="0" file="Source/MainComponent.h"/>
+        <FILE id="mZXg9O" name="MainComponent.cpp" compile="1" resource="0"
+              file="Source/MainComponent.cpp"/>
+      </GROUP>
       <FILE id="yHzpTk" name="Main.cpp" compile="1" resource="0" file="Source/Main.cpp"/>
     </GROUP>
   </MAINGROUP>
@@ -30,6 +43,46 @@
         <MODULEPATH id="juce_opengl" path="../JUCE/modules"/>
       </MODULEPATHS>
     </VS2019>
+    <VS2017 targetFolder="Builds/VisualStudio2017">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_cryptography"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </VS2017>
+    <XCODE_MAC targetFolder="Builds/MacOSX">
+      <CONFIGURATIONS>
+        <CONFIGURATION isDebug="1" name="Debug"/>
+        <CONFIGURATION isDebug="0" name="Release"/>
+      </CONFIGURATIONS>
+      <MODULEPATHS>
+        <MODULEPATH id="juce_opengl"/>
+        <MODULEPATH id="juce_gui_extra"/>
+        <MODULEPATH id="juce_gui_basics"/>
+        <MODULEPATH id="juce_graphics"/>
+        <MODULEPATH id="juce_events"/>
+        <MODULEPATH id="juce_data_structures"/>
+        <MODULEPATH id="juce_cryptography"/>
+        <MODULEPATH id="juce_core"/>
+        <MODULEPATH id="juce_audio_processors"/>
+        <MODULEPATH id="juce_audio_formats"/>
+        <MODULEPATH id="juce_audio_devices"/>
+        <MODULEPATH id="juce_audio_basics"/>
+      </MODULEPATHS>
+    </XCODE_MAC>
   </EXPORTFORMATS>
   <MODULES>
     <MODULE id="juce_audio_basics" showAllCode="1" useLocalCopy="0" useGlobalPath="0"/>

--- a/JUCE GUI/Moving-Speakers-GUI/Source/LogComponent.cpp
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/LogComponent.cpp
@@ -1,0 +1,131 @@
+/*
+  ==============================================================================
+
+  This is an automatically generated GUI class created by the Projucer!
+
+  Be careful when adding custom code to these files, as only the code within
+  the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
+  and re-saved.
+
+  Created with Projucer version: 5.4.7
+
+  ------------------------------------------------------------------------------
+
+  The Projucer is part of the JUCE library.
+  Copyright (c) 2017 - ROLI Ltd.
+
+  ==============================================================================
+*/
+
+//[Headers] You can add your own extra header files here...
+//[/Headers]
+
+#include "LogComponent.h"
+
+
+//[MiscUserDefs] You can add your own user definitions and misc code here...
+//[/MiscUserDefs]
+
+//==============================================================================
+LogComponent::LogComponent ()
+{
+    //[Constructor_pre] You can add your own custom stuff here..
+    //[/Constructor_pre]
+
+    textEditor.reset (new TextEditor ("new text editor"));
+    addAndMakeVisible (textEditor.get());
+    textEditor->setMultiLine (true);
+    textEditor->setReturnKeyStartsNewLine (true);
+    textEditor->setReadOnly (true);
+    textEditor->setScrollbarsShown (true);
+    textEditor->setCaretVisible (false);
+    textEditor->setPopupMenuEnabled (false);
+    textEditor->setText (String());
+
+
+    //[UserPreSize]
+    //[/UserPreSize]
+
+    setSize (600, 400);
+
+
+    //[Constructor] You can add your own custom stuff here..
+    //[/Constructor]
+}
+
+LogComponent::~LogComponent()
+{
+    //[Destructor_pre]. You can add your own custom destruction code here..
+    //[/Destructor_pre]
+
+    textEditor = nullptr;
+
+
+    //[Destructor]. You can add your own custom destruction code here..
+    //[/Destructor]
+}
+
+//==============================================================================
+void LogComponent::paint (Graphics& g)
+{
+    //[UserPrePaint] Add your own custom painting code here..
+    //[/UserPrePaint]
+
+    g.fillAll (Colour (0xff323e44));
+
+    //[UserPaint] Add your own custom painting code here..
+    //[/UserPaint]
+}
+
+void LogComponent::resized()
+{
+    //[UserPreResize] Add your own custom resize code here..
+    //[/UserPreResize]
+
+    textEditor->setBounds (0, 0, proportionOfWidth (1.0000f), proportionOfHeight (1.0000f));
+    //[UserResized] Add your own custom resize handling here..
+    //[/UserResized]
+}
+
+
+
+//[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
+
+void LogComponent::logMessage(const String& m)
+{
+	textEditor->moveCaretToEnd();
+	textEditor->insertTextAtCaret(m + newLine);
+}
+
+
+//[/MiscUserCode]
+
+
+//==============================================================================
+#if 0
+/*  -- Projucer information section --
+
+    This is where the Projucer stores the metadata that describe this GUI layout, so
+    make changes in here at your peril!
+
+BEGIN_JUCER_METADATA
+
+<JUCER_COMPONENT documentType="Component" className="LogComponent" componentName=""
+                 parentClasses="public Component, public Logger" constructorParams=""
+                 variableInitialisers="" snapPixels="8" snapActive="1" snapShown="1"
+                 overlayOpacity="0.330" fixedSize="0" initialWidth="600" initialHeight="400">
+  <BACKGROUND backgroundColour="ff323e44"/>
+  <TEXTEDITOR name="new text editor" id="6ebb4bdaf6eb980e" memberName="textEditor"
+              virtualName="" explicitFocusOrder="0" pos="0 0 100% 100%" initialText=""
+              multiline="1" retKeyStartsLine="1" readonly="1" scrollbars="1"
+              caret="0" popupmenu="0"/>
+</JUCER_COMPONENT>
+
+END_JUCER_METADATA
+*/
+#endif
+
+
+//[EndFile] You can add extra defines here...
+//[/EndFile]
+

--- a/JUCE GUI/Moving-Speakers-GUI/Source/LogComponent.h
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/LogComponent.h
@@ -1,0 +1,71 @@
+/*
+  ==============================================================================
+
+  This is an automatically generated GUI class created by the Projucer!
+
+  Be careful when adding custom code to these files, as only the code within
+  the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
+  and re-saved.
+
+  Created with Projucer version: 5.4.7
+
+  ------------------------------------------------------------------------------
+
+  The Projucer is part of the JUCE library.
+  Copyright (c) 2017 - ROLI Ltd.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+//[Headers]     -- You can add your own extra header files here --
+#include "../JuceLibraryCode/JuceHeader.h"
+//[/Headers]
+
+
+
+//==============================================================================
+/**
+                                                                    //[Comments]
+    A simple log window to monitor information in the app.
+	Implements Juce's Logger interface.
+                                                                    //[/Comments]
+*/
+class LogComponent  : public Component,
+                      public Logger
+{
+public:
+    //==============================================================================
+    LogComponent ();
+    ~LogComponent() override;
+
+    //==============================================================================
+    //[UserMethods]     -- You can add your own custom methods in this section.
+
+
+    void logMessage(const String& m);
+
+
+    //[/UserMethods]
+
+    void paint (Graphics& g) override;
+    void resized() override;
+
+
+
+private:
+    //[UserVariables]   -- You can add your own custom variables in this section.
+    //[/UserVariables]
+
+    //==============================================================================
+    std::unique_ptr<TextEditor> textEditor;
+
+
+    //==============================================================================
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (LogComponent)
+};
+
+//[EndFile] You can add extra defines here...
+//[/EndFile]
+

--- a/JUCE GUI/Moving-Speakers-GUI/Source/MainComponent.cpp
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/MainComponent.cpp
@@ -12,10 +12,26 @@
 MainComponent::MainComponent()
 {
     setSize (600, 400);
+
+	Logger::setCurrentLogger(&_logComponent);
+
+	File midiSettingsFile(File::getCurrentWorkingDirectory().getChildFile("../../midiconfig.json"));
+
+	if(_midiSettings.load(midiSettingsFile)) {
+
+		Logger::writeToLog(_midiSettings.toString());
+	}
+	else {
+
+		AlertWindow::showMessageBox(AlertWindow::WarningIcon, "Error", "Failed to load MIDI settings from file 'midiconfig.json'", "Quit", this);
+	
+		JUCEApplication::getInstance()->systemRequestedQuit();
+	}
 }
 
 MainComponent::~MainComponent()
 {
+	Logger::setCurrentLogger(nullptr);
 }
 
 //==============================================================================
@@ -24,9 +40,13 @@ void MainComponent::paint (Graphics& g)
     // (Our component is opaque, so we must completely fill the background with a solid colour)
     g.fillAll (getLookAndFeel().findColour (ResizableWindow::backgroundColourId));
 
-    g.setFont (Font (16.0f));
-    g.setColour (Colours::white);
-    g.drawText ("Hello World!", getLocalBounds(), Justification::centred, true);
+    //g.setFont (Font (16.0f));
+    //g.setColour (Colours::white);
+    //g.drawText ("Hello World!", getLocalBounds(), Justification::centred, true);
+    
+    
+	addAndMakeVisible(_logComponent);
+	addAndMakeVisible(_tabsComponent);
 }
 
 void MainComponent::resized()
@@ -34,4 +54,16 @@ void MainComponent::resized()
     // This is called when the MainComponent is resized.
     // If you add any child components, this is where you should
     // update their positions.
+    
+    FlexBox fb;
+	fb.flexDirection = FlexBox::Direction::column;
+	fb.flexWrap = FlexBox::Wrap::noWrap;
+	fb.justifyContent = FlexBox::JustifyContent::center;
+	fb.alignContent = FlexBox::AlignContent::stretch;
+	fb.alignItems = FlexBox::AlignItems::stretch;
+
+	fb.items.add(FlexItem(600, 300, _tabsComponent).withFlex(0.9f, 1.1f, 1.0f));
+	fb.items.add(FlexItem(600, 100, _logComponent));
+	
+	fb.performLayout(getLocalBounds().toFloat());
 }

--- a/JUCE GUI/Moving-Speakers-GUI/Source/MainComponent.h
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/MainComponent.h
@@ -9,6 +9,9 @@
 #pragma once
 
 #include <JuceHeader.h>
+#include "LogComponent.h"
+#include "TabsComponent.h"
+#include "MidiSettings.h"
 
 //==============================================================================
 /*
@@ -30,6 +33,10 @@ private:
     //==============================================================================
     // Your private member variables go here...
 
+    LogComponent	_logComponent;
+    TabsComponent	_tabsComponent;
+	rdd::MidiSettings	_midiSettings;
+    
 
     JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (MainComponent)
 };

--- a/JUCE GUI/Moving-Speakers-GUI/Source/MidiSettings.cpp
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/MidiSettings.cpp
@@ -1,0 +1,154 @@
+/*
+  ==============================================================================
+
+    MidiSettings.cpp
+    Created: 6 May 2020 9:26:49pm
+    Author:  Oliver Mayer
+
+  ==============================================================================
+*/
+
+#include "MidiSettings.h"
+
+using namespace rdd;
+
+
+MidiSettings::MidiSettings()
+{
+
+	_channel = 1;
+
+	_notes[MOVE_FORWARD] = 20;
+	_notes[MOVE_BACKWARD] = 21;
+	_notes[STRAFE_LEFT] = 22;
+	_notes[STRAFE_RIGHT] = 23;
+	_notes[ROTATE_LEFT] = 24;
+	_notes[ROTATE_RIGHT] = 25;
+	_notes[SPEAKER_UP] = 26;
+	_notes[SPEAKER_DOWN] = 27;
+
+	_cc[MOVE_SPEED] = 30;
+	_cc[ROTATE_SPEED] = 31;
+	_cc[SPEAKER_SPEED] = 32;
+}
+
+
+MidiSettings::~MidiSettings() {
+
+}
+
+
+bool MidiSettings::load(const File& file) {
+
+	var midisettings = JSON::parse(file);
+
+	return validateAndRead(midisettings);
+}
+
+
+int MidiSettings::getChannel() {
+	return _channel;
+}
+
+
+int MidiSettings::getNote(BotCommand cmd) {
+	return _notes.find(cmd)->second;
+}
+
+
+int MidiSettings::getCC(BotParameter param) {
+	return _cc.find(param)->second;
+}
+
+
+String MidiSettings::toString() {
+	String s = "MidiSettings:\n";
+	s += " channel:            " + String(_channel) + "\n";
+	s += " note move_forward:  " + String(getNote(MOVE_FORWARD)) + "\n";
+	s += " note move_backward: " + String(getNote(MOVE_BACKWARD)) + "\n";
+	s += " note strafe_left:   " + String(getNote(STRAFE_LEFT)) + "\n";
+	s += " note strafe_right:  " + String(getNote(STRAFE_RIGHT)) + "\n";
+	s += " note rotate_left:   " + String(getNote(ROTATE_LEFT)) + "\n";
+	s += " note rotate_right:  " + String(getNote(ROTATE_RIGHT)) + "\n";
+	s += " note speaker_up:    " + String(getNote(SPEAKER_UP)) + "\n";
+	s += " note speaker_down:  " + String(getNote(SPEAKER_DOWN)) + "\n";
+	s += " cc move_speed:      " + String(getCC(MOVE_SPEED)) + "\n";
+	s += " cc rotate_speed:    " + String(getCC(ROTATE_SPEED)) + "\n";
+	s += " cc speaker_speed:   " + String(getCC(SPEAKER_SPEED)) + "\n";
+
+	return s;
+}
+
+
+
+bool MidiSettings::validateAndRead(var json) {
+
+	if (json.isObject()) {
+		auto* obj = json.getDynamicObject();
+
+		bool ret = true;
+
+		ret &= getIntFromJsonObject(obj, "channel", _channel);
+
+
+		auto* objNotes = getChildObjectFromJsonObject(obj, "notes");
+		if (objNotes != nullptr) {
+			ret &= getIntFromJsonObject(objNotes, "move_forward", _notes[MOVE_FORWARD]);
+			ret &= getIntFromJsonObject(objNotes, "move_backward", _notes[MOVE_BACKWARD]);
+			ret &= getIntFromJsonObject(objNotes, "strafe_left", _notes[STRAFE_LEFT]);
+			ret &= getIntFromJsonObject(objNotes, "strafe_right", _notes[STRAFE_RIGHT]);
+			ret &= getIntFromJsonObject(objNotes, "rotate_left", _notes[ROTATE_LEFT]);
+			ret &= getIntFromJsonObject(objNotes, "rotate_right", _notes[ROTATE_RIGHT]);
+			ret &= getIntFromJsonObject(objNotes, "speaker_up", _notes[SPEAKER_UP]);
+			ret &= getIntFromJsonObject(objNotes, "speaker_down", _notes[SPEAKER_DOWN]);
+		}
+		else
+			ret = false;
+
+		auto* objCC = getChildObjectFromJsonObject(obj, "controlchange");
+		if (objCC != nullptr) {
+			ret &= getIntFromJsonObject(objCC, "move_speed", _cc[MOVE_SPEED]);
+			ret &= getIntFromJsonObject(objCC, "rotate_speed", _cc[ROTATE_SPEED]);
+			ret &= getIntFromJsonObject(objCC, "speaker_speed", _cc[SPEAKER_SPEED]);
+		}
+		else
+			ret = false;
+
+
+		return ret;
+	}
+	else
+		return false;
+}
+
+
+bool MidiSettings::getIntFromJsonObject(DynamicObject* obj, const String& id, int& buffer) {
+
+	if (obj->hasProperty(Identifier(id))) {
+		auto prop = obj->getProperty(Identifier(id));
+		if (prop.isInt()) {
+			buffer = prop.operator int();
+			return true;
+		}
+		else
+			return false;
+	}
+	else
+		return false;
+}		
+
+
+DynamicObject* MidiSettings::getChildObjectFromJsonObject(DynamicObject* obj, const String& id) {
+
+	if (obj->hasProperty(Identifier(id))) {
+		auto prop = obj->getProperty(Identifier(id));
+		if (prop.isObject()) {
+			return prop.getDynamicObject();
+		}
+		else
+			return nullptr;
+	}
+	else
+		return nullptr;
+
+}

--- a/JUCE GUI/Moving-Speakers-GUI/Source/MidiSettings.h
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/MidiSettings.h
@@ -1,0 +1,78 @@
+/*
+  ==============================================================================
+
+    MidiSettings.h
+    Created: 6 May 2020 9:26:49pm
+    Author:  Oliver Mayer
+
+  ==============================================================================
+*/
+
+#pragma once
+
+#include <JuceHeader.h>
+
+using namespace juce;
+
+namespace rdd {
+
+	class MidiSettings {
+
+	public:
+
+		enum BotCommand {
+			MOVE_FORWARD,
+			MOVE_BACKWARD,
+			STRAFE_LEFT,
+			STRAFE_RIGHT,
+			ROTATE_LEFT,
+			ROTATE_RIGHT,
+			SPEAKER_UP,
+			SPEAKER_DOWN
+		};
+
+		enum BotParameter {
+			MOVE_SPEED,
+			ROTATE_SPEED,
+			SPEAKER_SPEED
+		};
+
+
+
+		MidiSettings();
+
+		virtual ~MidiSettings();
+
+
+		bool load(const File& file);
+
+		int getChannel();
+
+		int getNote(BotCommand cmd);
+
+		int getCC(BotParameter param);
+
+		String toString();
+
+
+	protected:
+		
+		bool validateAndRead(var json);
+
+		bool getIntFromJsonObject(DynamicObject* obj, const String& id, int& buffer);
+
+		DynamicObject* getChildObjectFromJsonObject(DynamicObject* obj, const String& id);
+
+
+	protected:
+
+		int	_channel;
+
+		std::map<BotCommand, int> _notes;
+
+		std::map<BotParameter, int>	_cc;
+
+
+	};
+
+}

--- a/JUCE GUI/Moving-Speakers-GUI/Source/TabsComponent.cpp
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/TabsComponent.cpp
@@ -1,0 +1,134 @@
+/*
+  ==============================================================================
+
+  This is an automatically generated GUI class created by the Projucer!
+
+  Be careful when adding custom code to these files, as only the code within
+  the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
+  and re-saved.
+
+  Created with Projucer version: 5.4.5
+
+  ------------------------------------------------------------------------------
+
+  The Projucer is part of the JUCE library.
+  Copyright (c) 2017 - ROLI Ltd.
+
+  ==============================================================================
+*/
+
+//[Headers] You can add your own extra header files here...
+//[/Headers]
+
+#include "TabsComponent.h"
+
+
+//[MiscUserDefs] You can add your own user definitions and misc code here...
+//[/MiscUserDefs]
+
+//==============================================================================
+TabsComponent::TabsComponent ()
+{
+    //[Constructor_pre] You can add your own custom stuff here..
+    //[/Constructor_pre]
+
+    tabbedComponent.reset (new TabbedComponent (TabbedButtonBar::TabsAtTop));
+    addAndMakeVisible (tabbedComponent.get());
+    tabbedComponent->setTabBarDepth (30);
+    tabbedComponent->addTab (TRANS("Manual Control"), Colours::lightgrey, 0, false);
+    tabbedComponent->addTab (TRANS("Waypoint Editor"), Colours::lightgrey, 0, false);
+    tabbedComponent->addTab (TRANS("Settings"), Colours::lightgrey, 0, false);
+    tabbedComponent->setCurrentTabIndex (0);
+
+
+    //[UserPreSize]
+
+	Colour tabColor = getLookAndFeel().findColour(ResizableWindow::backgroundColourId);
+
+	tabbedComponent->setTabBackgroundColour(0, tabColor);
+	tabbedComponent->setTabBackgroundColour(1, tabColor);
+	tabbedComponent->setTabBackgroundColour(2, tabColor);
+
+    //[/UserPreSize]
+
+    setSize (600, 400);
+
+
+    //[Constructor] You can add your own custom stuff here..
+    //[/Constructor]
+}
+
+TabsComponent::~TabsComponent()
+{
+    //[Destructor_pre]. You can add your own custom destruction code here..
+    //[/Destructor_pre]
+
+    tabbedComponent = nullptr;
+
+
+    //[Destructor]. You can add your own custom destruction code here..
+    //[/Destructor]
+}
+
+//==============================================================================
+void TabsComponent::paint (Graphics& g)
+{
+    //[UserPrePaint] Add your own custom painting code here..
+    //[/UserPrePaint]
+
+    g.fillAll (Colour (0xff323e44));
+
+    //[UserPaint] Add your own custom painting code here..
+    //[/UserPaint]
+}
+
+void TabsComponent::resized()
+{
+    //[UserPreResize] Add your own custom resize code here..
+    //[/UserPreResize]
+
+    tabbedComponent->setBounds (0, 0, proportionOfWidth (1.0000f), proportionOfHeight (1.0000f));
+    //[UserResized] Add your own custom resize handling here..
+    //[/UserResized]
+}
+
+
+
+//[MiscUserCode] You can add your own definitions of your custom methods or any other code here...
+//[/MiscUserCode]
+
+
+//==============================================================================
+#if 0
+/*  -- Projucer information section --
+
+    This is where the Projucer stores the metadata that describe this GUI layout, so
+    make changes in here at your peril!
+
+BEGIN_JUCER_METADATA
+
+<JUCER_COMPONENT documentType="Component" className="TabsComponent" componentName=""
+                 parentClasses="public Component" constructorParams="" variableInitialisers=""
+                 snapPixels="8" snapActive="1" snapShown="1" overlayOpacity="0.330"
+                 fixedSize="0" initialWidth="600" initialHeight="400">
+  <BACKGROUND backgroundColour="ff323e44"/>
+  <TABBEDCOMPONENT name="new tabbed component" id="96829c8fe1730fce" memberName="tabbedComponent"
+                   virtualName="" explicitFocusOrder="0" pos="0 0 100% 100%" orientation="top"
+                   tabBarDepth="30" initialTab="0">
+    <TAB name="Manual Control" colour="ffd3d3d3" useJucerComp="0" contentClassName=""
+         constructorParams="" jucerComponentFile=""/>
+    <TAB name="Waypoint Editor" colour="ffd3d3d3" useJucerComp="0" contentClassName=""
+         constructorParams="" jucerComponentFile=""/>
+    <TAB name="Settings" colour="ffd3d3d3" useJucerComp="0" contentClassName=""
+         constructorParams="" jucerComponentFile=""/>
+  </TABBEDCOMPONENT>
+</JUCER_COMPONENT>
+
+END_JUCER_METADATA
+*/
+#endif
+
+
+//[EndFile] You can add extra defines here...
+//[/EndFile]
+

--- a/JUCE GUI/Moving-Speakers-GUI/Source/TabsComponent.h
+++ b/JUCE GUI/Moving-Speakers-GUI/Source/TabsComponent.h
@@ -1,0 +1,66 @@
+/*
+  ==============================================================================
+
+  This is an automatically generated GUI class created by the Projucer!
+
+  Be careful when adding custom code to these files, as only the code within
+  the "//[xyz]" and "//[/xyz]" sections will be retained when the file is loaded
+  and re-saved.
+
+  Created with Projucer version: 5.4.5
+
+  ------------------------------------------------------------------------------
+
+  The Projucer is part of the JUCE library.
+  Copyright (c) 2017 - ROLI Ltd.
+
+  ==============================================================================
+*/
+
+#pragma once
+
+//[Headers]     -- You can add your own extra header files here --
+#include "../JuceLibraryCode/JuceHeader.h"
+//[/Headers]
+
+
+
+//==============================================================================
+/**
+                                                                    //[Comments]
+    An auto-generated component, created by the Projucer.
+
+    Describe your class and how it works here!
+                                                                    //[/Comments]
+*/
+class TabsComponent  : public Component
+{
+public:
+    //==============================================================================
+    TabsComponent ();
+    ~TabsComponent();
+
+    //==============================================================================
+    //[UserMethods]     -- You can add your own custom methods in this section.
+    //[/UserMethods]
+
+    void paint (Graphics& g) override;
+    void resized() override;
+
+
+
+private:
+    //[UserVariables]   -- You can add your own custom variables in this section.
+    //[/UserVariables]
+
+    //==============================================================================
+    std::unique_ptr<TabbedComponent> tabbedComponent;
+
+
+    //==============================================================================
+    JUCE_DECLARE_NON_COPYABLE_WITH_LEAK_DETECTOR (TabsComponent)
+};
+
+//[EndFile] You can add extra defines here...
+//[/EndFile]
+

--- a/JUCE GUI/Moving-Speakers-GUI/midiconfig.json
+++ b/JUCE GUI/Moving-Speakers-GUI/midiconfig.json
@@ -1,0 +1,18 @@
+{  
+    "channel": 1,  
+    "notes": {    
+        "move_forward": 10,   
+        "move_backward": 11,    
+        "strafe_left": 12,    
+        "strafe_right": 13,    
+        "rotate_left": 14,    
+        "rotate_right": 15,    
+        "speaker_up": 16,    
+        "speaker_down": 17  
+    },  
+    "controlchange": {    
+        "move_speed": 20,    
+        "rotate_speed": 21,    
+        "speaker_speed": 22  
+    }
+}


### PR DESCRIPTION
VisualStudio 2017 and MacOS exporters added to the Projucer project.

LogComponent added: A simple TextEditor component for in-app monitoring of events. Uses Juce's logging interface.
TabsComponent added: A simple placeholder component with tabs

MidiSettings added: A class to read midi settings from a JSON file. Uses Juce's JSON and var objects.

I added everything to the main app for you to see how everything works

